### PR TITLE
fix(ci): add scope to setup-node for npm registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
               with:
                   node-version-file: .node-version
                   registry-url: https://registry.npmjs.org/
+                  scope: '@doist'
 
             - name: Publish package to npm registry
               run: npm publish --access public --provenance


### PR DESCRIPTION
Follow up fix on: https://github.com/Doist/react-compiler-tracker/pull/19

The second setup-node action was missing the scope parameter, causing npm publish to use the GitHub Packages registry config from the first setup-node instead of the npmjs.org registry.

<img width="1265" height="936" alt="image" src="https://github.com/user-attachments/assets/f97d2d27-3ca0-41d2-9d74-d269b7349ea1" />
