### PR TITLE
chore(deps): extend tsconfig from @doist/tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
+        "@doist/tsconfig": "2.0.1",
         "@types/babel__core": "7.20.5",
         "@types/node": "25.0.8",
         "babel-plugin-react-compiler": "1.0.0",
@@ -688,6 +689,13 @@
       "engines": {
         "node": ">=14.21.3"
       }
+    },
+    "node_modules/@doist/tsconfig": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@doist/tsconfig/-/tsconfig-2.0.1.tgz",
+      "integrity": "sha512-U2VHM9UU7kdteiSSyuTSUDVtQiHr+bEuXREkdI/TqXQNeA1XP40mJdbQs4PN3VCxSjJ7Z0RHiKGxjZWY9Giw4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
+    "@doist/tsconfig": "2.0.1",
     "@types/babel__core": "7.20.5",
     "@types/node": "25.0.8",
     "babel-plugin-react-compiler": "1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
+    "extends": "@doist/tsconfig",
     "compilerOptions": {
         "target": "ES2022",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "outDir": "dist",
         "rootDir": "src",
-        "strict": true,
         "skipLibCheck": true
     },
     "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
- Add `@doist/tsconfig` as a dev dependency
- Update `tsconfig.json` to extend from `@doist/tsconfig`
- Remove redundant `strict: true` (inherited from base config)

## Test plan
- [x] `npm run check:types` passes
- [x] `npm run build` succeeds
- [x] `npm test` passes (55 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)