### PR TITLE
fix: drop Node 20 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "vitest": "4.1.8"
       },
       "engines": {
-        "node": "^20.0.0 || >=22.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "babel-plugin-react-compiler": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/Doist/react-compiler-tracker#readme",
   "engines": {
-    "node": "^20.0.0 || >=22.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Overview

Drops Node 20 from the package's `engines` field, changing it from `^20.0.0 || >=22.0.0` to `>=22.0.0`.

Node 20 reached end-of-life on 2026-04-30, so declaring support for it is no longer accurate. This also unblocks #135 (npm-run-all2 → v9), whose dev tooling requires Node `^22.22.2` and would otherwise contradict a declared Node 20 floor.

This partially reverses #43, which had relaxed the engine requirement to add Node 20 support while it was still maintained.

Note: `npm-run-all2` is a `devDependency`, so this only affects contributors and CI — published-package consumers' runtime is unchanged. CI and local environments already run Node 22 via `.node-version` (`22.22`).

## Test plan

- [ ] `npm run check` passes on Node 22
- [ ] `npm run test` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)