### PR TITLE
chore: sync biome.json schema to 2.4.16

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
## Overview

The `$schema` URL in `biome.json` was pinned to `2.4.8` while the installed `@biomejs/biome` had been bumped to `2.4.16` (#138). Renovate updates the npm dependency but not the in-file schema URL, so `biome check` emitted a schema-version mismatch info on every run:

> The configuration schema version does not match the CLI version 2.4.16

This aligns the schema URL with the installed CLI version. After the change the `Found 1 info` line is gone and `check:biome` reports clean.

## Test plan

- [ ] `npm run check` runs without the schema-version mismatch info