### PR TITLE
ci: bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Prepare Node.js environment
               uses: actions/setup-node@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
-            - uses: googleapis/release-please-action@v4
+            - uses: googleapis/release-please-action@v5
               id: release
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6
- `googleapis/release-please-action` v4 → v5

Tracking: https://github.com/Doist/platform-backlog/issues/1385
